### PR TITLE
Fix Not Matching Images In A Multi Path Scenario 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "os-tester"
-version = "1.0.1"
+version = "1.0.2.dev1"
 authors = [
   { name="Fabian Sauter", email="fabian.sauter+pip@apsensing.com" }
 ]

--- a/src/os_tester/vm.py
+++ b/src/os_tester/vm.py
@@ -165,7 +165,7 @@ class vm:
             for index, refImg in enumerate(refImgList, start=0):
                 mse, ssimIndex, difImg = self.__comp_images(curImg, refImg)
 
-                same: float = 1 if mse < subPathObj.checkMseLeq and ssimIndex > subPathObj.checkSsimGeq else 0
+                same: float = 1 if mse <= subPathObj.checkMseLeq and ssimIndex >= subPathObj.checkSsimGeq else 0
                 print(f"MSE: {mse}, SSIM: {ssimIndex}, Images Same: {same}")
                 if self.debugPlt:
                     self.debugPlotObj.update_plot(refImg, curImg, difImg, mse, ssimIndex, same)

--- a/src/os_tester/vm.py
+++ b/src/os_tester/vm.py
@@ -174,7 +174,7 @@ class vm:
                 mse, ssimIndex, difImg = self.__comp_images(curImg, refImg)
                 same: float = 1 if mse <= subPathObj.checkMseLeq and ssimIndex >= subPathObj.checkSsimGeq else 0
 
-                print(f"{refImgPath} with MSE leq {subPathObj.checkMseLeq} and SSIM geq {subPathObj.checkSsimGeq} - MSE: {mse}, SSIM: {ssimIndex}, Images Same: {same}")
+                print(f"{subPathObj.checkFile} with MSE leq {subPathObj.checkMseLeq} and SSIM geq {subPathObj.checkSsimGeq} - MSE: {mse}, SSIM: {ssimIndex}, Images Same: {same}")
                 if self.debugPlt:
                     self.debugPlotObj.update_plot(refImg, curImg, difImg, mse, ssimIndex, same)
 

--- a/src/os_tester/vm.py
+++ b/src/os_tester/vm.py
@@ -294,15 +294,13 @@ class vm:
         stream: libvirt.virStream = self.conn.newStream()
 
         assert self.vmDom
-        imgType: Any = self.vmDom.screenshot(stream, 0)
+        _ = self.vmDom.screenshot(stream, 0)
 
         with open(targetPath, "wb") as f:
             streamBytes = stream.recv(262120)
             while streamBytes != b"":
                 f.write(streamBytes)
                 streamBytes = stream.recv(262120)
-
-        print(f"Screenshot saved as type '{imgType}' under '{targetPath}'.")
         stream.finish()
 
     def __get_screen_size(self) -> Tuple[int, int]:


### PR DESCRIPTION
When there are multiple paths, image comparisons relied on undefined behaviour. This is now fixed.