### PR TITLE
Area based SSIM Checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ stages:
           checks:
             - file:
               path: 0.png
-              mse_leq: 0.1
               ssim_geq: 0.99
           actions:
             - keyboard_key:
@@ -166,7 +165,6 @@ stages:
           checks:
             - file:
               path: 0_1.png
-              mse_leq: 0.1
               ssim_geq: 0.99
           actions:
             - keyboard_key:
@@ -187,7 +185,6 @@ stages:
           checks:
             - file:
               path: 1.png
-              mse_leq: 0.1
               ssim_geq: 0.99
           actions:
             - keyboard_key:
@@ -202,7 +199,6 @@ stages:
           checks:
             - file:
               path: 2.png
-              mse_leq: 0.1
               ssim_geq: 0.99
           actions:
             - keyboard_key:
@@ -223,7 +219,6 @@ stages:
           checks:
             - file:
               path: 3.png
-              mse_leq: 0.1
               ssim_geq: 0.99
           actions:
             - keyboard_text:

--- a/examples/stages/stages.yml
+++ b/examples/stages/stages.yml
@@ -8,7 +8,6 @@ stages:
           checks:
             - file:
               path: 0.png
-              mse_leq: 0.1
               ssim_geq: 0.99
           actions:
             - keyboard_key:
@@ -22,7 +21,6 @@ stages:
           checks:
             - file:
               path: 0_1.png
-              mse_leq: 0.1
               ssim_geq: 0.99
           actions:
             - keyboard_key:
@@ -43,7 +41,6 @@ stages:
           checks:
             - file:
               path: 1.png
-              mse_leq: 0.1
               ssim_geq: 0.99
           actions:
             - keyboard_key:
@@ -58,7 +55,6 @@ stages:
           checks:
             - file:
               path: 2.png
-              mse_leq: 0.1
               ssim_geq: 0.99
           actions:
             - keyboard_key:
@@ -79,7 +75,6 @@ stages:
           check:
             - file:
               path: 3.png
-              mse_leq: 0.1
               ssim_geq: 0.99
           actions:
             - keyboard_text:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "os-tester"
-version = "1.2.0.dev1"
+version = "1.2.0"
 authors = [
   { name="Fabian Sauter", email="fabian.sauter+pip@apsensing.com" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "os-tester"
-version = "1.1.0"
+version = "1.2.0.dev1"
 authors = [
   { name="Fabian Sauter", email="fabian.sauter+pip@apsensing.com" }
 ]

--- a/src/os_tester/debug_plot.py
+++ b/src/os_tester/debug_plot.py
@@ -9,14 +9,12 @@ class debugPlot:
     A wrapper class around a matplotlib plot to visualize the current image output detection.
     """
 
-    mseValues: List[float]
     ssimValues: List[float]
     sameImageValues: List[float]
     fig: Any
     axd: Any
 
     def __init__(self):
-        self.mseValues: List[float] = list()
         self.ssimValues: List[float] = list()
         self.sameImageValues: List[float] = list()
 
@@ -32,7 +30,6 @@ class debugPlot:
         refImg: cv2.typing.MatLike,
         curImg: cv2.typing.MatLike,
         difImage: cv2.typing.MatLike,
-        mse: float,
         ssim: float,
         same: float,
     ) -> None:
@@ -43,11 +40,9 @@ class debugPlot:
             refImg (cv2.typing.MatLike): The reference image we are waiting for.
             curImg (cv2.typing.MatLike): The current VM output image.
             difImage (cv2.typing.MatLike): |refImg - curImg| aka the diff of those images.
-            mse (float): The mean square error between refImg and curImg.
             ssim (float): The structural similarity index error between refImg and curImg.
             same (float): 1 if refImg and curImg are equal enough and 0 else.
         """
-        self.mseValues.append(mse)
         self.ssimValues.append(ssim)
         self.sameImageValues.append(same)
 
@@ -64,14 +59,11 @@ class debugPlot:
         self.axd["difImg"].imshow(cv2.cvtColor(difImage, cv2.COLOR_BGR2RGB))
         self.axd["difImg"].set_title("Dif Image")
 
-        # Plot MSE over time
+        # Plot SSIM over time
         self.axd["plot"].clear()
-        self.axd["plot"].plot(self.mseValues, "bx-", label="MSE over Time")
         self.axd["plot"].plot(self.ssimValues, "rx-", label="SSIM over Time")
         self.axd["plot"].plot(self.sameImageValues, "gx-", label="Same Image")
-        self.axd["plot"].set_title("MSE over Time")
         self.axd["plot"].set_xlabel("Iterations")
-        self.axd["plot"].set_ylabel("MSE")
         self.axd["plot"].legend()
 
         plt.pause(0.001)  # Allows the plot to update

--- a/src/os_tester/stages.py
+++ b/src/os_tester/stages.py
@@ -51,7 +51,6 @@ class checkFile:
     filePath: str
     fileData: cv2.typing.MatLike
 
-    mseLeq: float
     ssimGeq: float
     area: Optional[area]
     nextStage: str
@@ -64,7 +63,6 @@ class checkFile:
         self.filePath = path.join(basePath, file_path)
         # Check if the reference images exist and if so load them as OpenCV object
         self.fileData = self.__load(self.filePath)
-        self.mseLeq = _validate_range(_require_key(fileDict, "mse_leq"), "mse_leq", 0.0, None)
         self.ssimGeq = _validate_range(_require_key(fileDict, "ssim_geq"), "ssim_geq", 0.0, 1.0)
 
         self.area = None

--- a/src/os_tester/stages.py
+++ b/src/os_tester/stages.py
@@ -1,9 +1,46 @@
 import sys
+from dataclasses import dataclass
 from os import path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import cv2
 import yaml  # type: ignore
+
+
+def _is_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _require_key(mapping: Dict[str, Any], key: str) -> Any:
+    if key not in mapping:
+        raise ValueError(f"Missing required key '{key}' in stage definition.")
+    return mapping[key]
+
+
+def _validate_range(value: Any, name: str, min_value: Optional[float], max_value: Optional[float]) -> float:
+    if not _is_number(value):
+        raise ValueError(f"Expected '{name}' to be a number, got '{type(value).__name__}'.")
+    value_f = float(value)
+    if min_value is not None and value_f < min_value:
+        raise ValueError(f"Expected '{name}' to be >= {min_value}, got {value_f}.")
+    if max_value is not None and value_f > max_value:
+        raise ValueError(f"Expected '{name}' to be <= {max_value}, got {value_f}.")
+    return value_f
+
+
+class area:
+    x1Percentage: float
+    x2Percentage: float
+    y1Percentage: float
+    y2Percentage: float
+
+    def __init__(self, areaDict: Dict[str, Any]):
+        self.x1Percentage = _validate_range(_require_key(areaDict, "x1Percentage"), "area.x1Percentage", 0.0, 1.0)
+        self.x2Percentage = _validate_range(_require_key(areaDict, "x2Percentage"), "area.x2Percentage", 0.0, 1.0)
+        self.y1Percentage = _validate_range(_require_key(areaDict, "y1Percentage"), "area.y1Percentage", 0.0, 1.0)
+        self.y2Percentage = _validate_range(_require_key(areaDict, "y2Percentage"), "area.y2Percentage", 0.0, 1.0)
+        if self.x1Percentage >= self.x2Percentage or self.y1Percentage >= self.y2Percentage:
+            raise ValueError("Expected area coordinates to satisfy x1Percentage < x2Percentage and y1Percentage < y2Percentage.")
 
 
 class checkFile:
@@ -16,15 +53,24 @@ class checkFile:
 
     mseLeq: float
     ssimGeq: float
+    area: Optional[area]
     nextStage: str
     actions: List[Dict[str, Any]]
 
     def __init__(self, fileDict: Dict[str, Any], basePath: str):
-        self.filePath = path.join(basePath, fileDict["path"])
+        file_path = _require_key(fileDict, "path")
+        if not isinstance(file_path, str):
+            raise ValueError("Expected 'path' to be a string.")
+        self.filePath = path.join(basePath, file_path)
         # Check if the reference images exist and if so load them as OpenCV object
         self.fileData = self.__load(self.filePath)
-        self.mseLeq = fileDict["mse_leq"]
-        self.ssimGeq = fileDict["ssim_geq"]
+        self.mseLeq = _validate_range(_require_key(fileDict, "mse_leq"), "mse_leq", 0.0, None)
+        self.ssimGeq = _validate_range(_require_key(fileDict, "ssim_geq"), "ssim_geq", 0.0, 1.0)
+
+        self.area = None
+        if "area" in fileDict:
+            areaDict: Dict[str, Any] = fileDict["area"]
+            self.area = area(areaDict)
 
     def __load(self, filePath: str) -> cv2.typing.MatLike:
         """
@@ -63,12 +109,16 @@ class subPath:
 
         self.checkList = list()
         if "checks" in pathDict:
+            if not isinstance(pathDict["checks"], list):
+                raise ValueError("Expected 'checks' to be a list.")
             checkDict: Dict[str, Any]
             for checkDict in pathDict["checks"]:
+                if not isinstance(checkDict, dict):
+                    raise ValueError("Expected each entry in 'checks' to be a mapping.")
                 self.checkList.append(checkFile(checkDict, basePath))
 
         self.actions = pathDict["actions"] if "actions" in pathDict else list()
-        self.nextStage = pathDict["nextStage"]
+        self.nextStage = _require_key(pathDict, "nextStage")
 
 
 class stage:
@@ -81,12 +131,17 @@ class stage:
     pathsList: List[subPath]
 
     def __init__(self, stageDict: Dict[str, Any], basePath: str):
-        self.name = stageDict["stage"]
-        self.timeoutS = stageDict["timeout_s"]
+        self.name = _require_key(stageDict, "stage")
+        self.timeoutS = _validate_range(_require_key(stageDict, "timeout_s"), "timeout_s", 0.0, None)
 
         self.pathsList = list()
+        paths = _require_key(stageDict, "paths")
+        if not isinstance(paths, list) or not paths:
+            raise ValueError("Expected 'paths' to be a non-empty list.")
         pathDict: Dict[str, Any]
-        for pathDict in stageDict["paths"]:
+        for pathDict in paths:
+            if not isinstance(pathDict, dict) or "path" not in pathDict:
+                raise ValueError("Expected each entry in 'paths' to contain a 'path' mapping.")
             self.pathsList.append(subPath(pathDict["path"], basePath))
 
 
@@ -117,9 +172,14 @@ class stages:
         with open(ymlFilePath, "r", encoding="utf-8") as file:
             stagesDict = yaml.safe_load(file)
 
+        if not isinstance(stagesDict["stages"], list):
+            raise ValueError("Expected 'stages' to be a list.")
+
         self.stagesList = list()
         stageDict: Dict[str, Any]
         for stageDict in stagesDict["stages"]:
+            if not isinstance(stageDict, dict):
+                raise ValueError("Expected each entry in 'stages' to be a mapping.")
             self.stagesList.append(stage(stageDict, self.basePath))
 
     def __init__(self, basePath: str, yamlFileName: str):

--- a/src/os_tester/vm.py
+++ b/src/os_tester/vm.py
@@ -105,7 +105,7 @@ class vm:
         Args:
             curImg (cv2.typing.MatLike): The current image taken from the VM.
             refImg (cv2.typing.MatLike): The reference image we are awaiting.
-            area (Optional[Area]): Optional sub-rectangle (normalized) used for comparison.
+            area (Optional[area]): Optional sub-rectangle (normalized) used for comparison.
 
         Returns:
             Tuple[float, cv2.typing.MatLike]: A tuple consisting of the structural similarity index and a image diff of both images.

--- a/stages_schema.yml
+++ b/stages_schema.yml
@@ -134,15 +134,35 @@ definitions:
     File:
         type: object
         additionalProperties: false
+        description: "Describes a file source for a reference image used during comparison."
         properties:
             path:
                 type: string
-            mse_leq:
-                type: number
+                description: "Path to the reference image used for comparison."
             ssim_geq:
                 type: number
+                description: "Minimum structural similarity index (https://scikit-image.org/docs/0.25.x/auto_examples/transform/plot_ssim.html) required, in the range [0.0, 1.0]."
+            area:
+                "$ref": "#/definitions/Area"
+                description: "Optional sub-rectangle to compare against the same-sized area in the captured OS image."
         required:
             - file
-            - mse_leq
             - ssim_geq
         title: file
+    Area:
+        type: object
+        additionalProperties: false
+        description: "Rectangle defined by X/Y coordinates as percentages of the full image."
+        properties:
+            x1Percentage:
+                type: number
+                description: "Left X coordinate of the comparison area, as a percentage in [0.0, 1.0]."
+            x2Percentage:
+                type: number
+                description: "Right X coordinate of the comparison area, as a percentage in [0.0, 1.0]."
+            y1Percentage:
+                type: number
+                description: "Top Y coordinate of the comparison area, as a percentage in [0.0, 1.0]."
+            y2Percentage:
+                type: number
+                description: "Bottom Y coordinate of the comparison area, as a percentage in [0.0, 1.0]."

--- a/tests/test_image_compare.py
+++ b/tests/test_image_compare.py
@@ -21,45 +21,43 @@ def _load_image(file_path: str) -> np.ndarray:
     return image
 
 
-def _compare_images(img_a: np.ndarray, img_b: np.ndarray, imageArea: Optional[area] = None) -> tuple[float, float]:
+def _compare_images(img_a: np.ndarray, img_b: np.ndarray, imageArea: Optional[area] = None) -> float:
     tester = vm(None, "pytest")
-    mse, ssim, _ = tester._vm__comp_images(img_a, img_b, imageArea)
-    return mse, ssim
+    ssim, _ = tester._vm__comp_images(img_a, img_b, imageArea)
+    return ssim
 
 
-def _compare_images_test(file_name_a: str, file_name_b: str, mse_expected: float, ssim_expected: float):
+def _compare_images_test(file_name_a: str, file_name_b: str, ssim_expected: float):
     basePath: str = f"{os.path.dirname(os.path.abspath(__file__))}/images"
     img_a = _load_image(f"{basePath}/{file_name_a}")
     img_b = _load_image(f"{basePath}/{file_name_b}")
-    mse, ssim = _compare_images(img_a, img_b)
+    ssim = _compare_images(img_a, img_b)
 
-    assert mse == pytest.approx(mse_expected, abs=1e-2)
     assert ssim == pytest.approx(ssim_expected, abs=1e-2)
 
 
 def test_compare_same_image_file() -> None:
-    _compare_images_test("a.png", "a.png", 0.0, 1.0)
+    _compare_images_test("a.png", "a.png", 1.0)
 
 
 def test_compare_similar_image() -> None:
-    _compare_images_test("a.png", "b.png", 0.0, 1.0)
-    _compare_images_test("a.png", "c.png", 6.005, 0.99)  # The difference is the cursor
+    _compare_images_test("a.png", "b.png", 1.0)
+    _compare_images_test("a.png", "c.png", 0.99)  # The difference is the cursor
 
 
 def test_compare_similar_luks_image() -> None:
-    _compare_images_test("luks_a.png", "luks_b.png", 300.52582, 0.97)
+    _compare_images_test("luks_a.png", "luks_b.png", 0.97)
 
 
 def test_compare_images_identical() -> None:
     img = np.zeros((64, 64, 3), dtype=np.uint8)
-    mse, ssim = _compare_images(img, img.copy())
+    ssim = _compare_images(img, img.copy())
 
-    assert mse == pytest.approx(0.0, abs=1e-2)
     assert ssim == pytest.approx(1.0, abs=1e-2)
 
 
 def test_compare_images_with_area_excludes_difference() -> None:
-    img_a = np.zeros((10, 10, 3), dtype=np.uint8)
+    img_a = np.zeros((100, 100, 3), dtype=np.uint8)
     img_b = img_a.copy()
     img_b[0, 0] = [255, 255, 255]
 
@@ -71,9 +69,7 @@ def test_compare_images_with_area_excludes_difference() -> None:
             "y2Percentage": 1.0,
         }
     )
-    mse, ssim = _compare_images(img_a, img_b, imageArea)
-
-    assert mse == pytest.approx(0.0, abs=1e-6)
+    ssim = _compare_images(img_a, img_b, imageArea)
     assert ssim == pytest.approx(1.0, abs=1e-2)
 
 
@@ -90,7 +86,5 @@ def test_compare_images_with_area_includes_difference() -> None:
             "y2Percentage": 0.9,
         }
     )
-    mse, ssim = _compare_images(img_a, img_b, imageArea)
-
-    assert mse > 0.0
+    ssim = _compare_images(img_a, img_b, imageArea)
     assert ssim < 0.999

--- a/tests/test_stages_parsing.py
+++ b/tests/test_stages_parsing.py
@@ -25,7 +25,6 @@ stages:
       - path:
           checks:
             - path: "ref.png"
-              mse_leq: 0.0
               ssim_geq: 0.9
               area:
                 x1Percentage: 0.1
@@ -54,7 +53,6 @@ stages:
       - path:
           checks:
             - path: "ref.png"
-              mse_leq: 0.0
               ssim_geq: 0.9
               area:
                 x1Percentage: 0.9
@@ -80,7 +78,6 @@ stages:
       - path:
           checks:
             - path: "ref.png"
-              mse_leq: 0.0
               ssim_geq: 1.5
           actions: []
           nextStage: "done"

--- a/tests/test_stages_parsing.py
+++ b/tests/test_stages_parsing.py
@@ -1,0 +1,91 @@
+import cv2
+import numpy as np
+import pytest
+
+from os_tester.stages import Area, stages
+
+
+def _write_stage_file(tmp_path, stage_dict) -> None:
+    stage_path = tmp_path / "stages.yml"
+    stage_path.write_text(stage_dict, encoding="utf-8")
+
+
+def _write_ref_image(tmp_path, name: str = "ref.png") -> None:
+    img = np.zeros((10, 10, 3), dtype=np.uint8)
+    cv2.imwrite(str(tmp_path / name), img)
+
+
+def test_stages_parsing_accepts_area(tmp_path) -> None:
+    _write_ref_image(tmp_path)
+    stage_yaml = """
+stages:
+  - stage: "boot"
+    timeout_s: 5
+    paths:
+      - path:
+          checks:
+            - path: "ref.png"
+              mse_leq: 0.0
+              ssim_geq: 0.9
+              area:
+                x1Percentage: 0.1
+                x2Percentage: 0.9
+                y1Percentage: 0.2
+                y2Percentage: 0.8
+          actions: []
+          nextStage: "done"
+"""
+    _write_stage_file(tmp_path, stage_yaml)
+
+    loaded = stages(str(tmp_path), "stages")
+    area = loaded.stagesList[0].pathsList[0].checkList[0].area
+
+    assert isinstance(area, Area)
+    assert area.x1Percentage == pytest.approx(0.1)
+
+
+def test_stages_parsing_rejects_invalid_area(tmp_path) -> None:
+    _write_ref_image(tmp_path)
+    stage_yaml = """
+stages:
+  - stage: "boot"
+    timeout_s: 5
+    paths:
+      - path:
+          checks:
+            - path: "ref.png"
+              mse_leq: 0.0
+              ssim_geq: 0.9
+              area:
+                x1Percentage: 0.9
+                x2Percentage: 0.1
+                y1Percentage: 0.2
+                y2Percentage: 0.8
+          actions: []
+          nextStage: "done"
+"""
+    _write_stage_file(tmp_path, stage_yaml)
+
+    with pytest.raises(ValueError, match="x1 < x2"):
+        stages(str(tmp_path), "stages")
+
+
+def test_stages_parsing_rejects_invalid_ssim(tmp_path) -> None:
+    _write_ref_image(tmp_path)
+    stage_yaml = """
+stages:
+  - stage: "boot"
+    timeout_s: 5
+    paths:
+      - path:
+          checks:
+            - path: "ref.png"
+              mse_leq: 0.0
+              ssim_geq: 1.5
+          actions: []
+          nextStage: "done"
+"""
+    _write_stage_file(tmp_path, stage_yaml)
+
+    with pytest.raises(ValueError, match="ssim_geq"):
+        stages(str(tmp_path), "stages")

--- a/tests/test_stages_parsing.py
+++ b/tests/test_stages_parsing.py
@@ -40,7 +40,7 @@ stages:
     imageArea = loaded.stagesList[0].pathsList[0].checkList[0].area
 
     assert isinstance(imageArea, area)
-    assert area.x1Percentage == pytest.approx(0.1)
+    assert imageArea.x1Percentage == pytest.approx(0.1)
 
 
 def test_stages_parsing_rejects_invalid_area(tmp_path) -> None:
@@ -64,7 +64,7 @@ stages:
 """
     _write_stage_file(tmp_path, stage_yaml)
 
-    with pytest.raises(ValueError, match="x1 < x2"):
+    with pytest.raises(ValueError, match="x1Percentage < x2Percentage"):
         stages(str(tmp_path), "stages")
 
 

--- a/tests/test_stages_parsing.py
+++ b/tests/test_stages_parsing.py
@@ -2,7 +2,7 @@ import cv2
 import numpy as np
 import pytest
 
-from os_tester.stages import Area, stages
+from os_tester.stages import area, stages
 
 
 def _write_stage_file(tmp_path, stage_dict) -> None:
@@ -37,9 +37,9 @@ stages:
     _write_stage_file(tmp_path, stage_yaml)
 
     loaded = stages(str(tmp_path), "stages")
-    area = loaded.stagesList[0].pathsList[0].checkList[0].area
+    imageArea = loaded.stagesList[0].pathsList[0].checkList[0].area
 
-    assert isinstance(area, Area)
+    assert isinstance(imageArea, area)
     assert area.x1Percentage == pytest.approx(0.1)
 
 


### PR DESCRIPTION
It is now possible to specify a relative area in which we will perform the SSIM check. Since this way of performing the image based comparison is far better than checking for SSIM and MSE combined, I removed MSE detection completely.

## Example Config

Take a look at the new optional `area` keyword.

```yaml
stages:
  - stage: Enter LUKS Password
    timeout_s: 600
    paths:
      - path:
          checks:
            - file:
              path: 0a.png
              ssim_geq: 0.99
              area:
                x1Percentage: 0.32
                x2Percentage: 0.68
                y1Percentage: 0.34
                y2Percentage: 0.42
            - file:
              path: 0b.png
              ssim_geq: 0.99
              area:
                x1Percentage: 0.27
                x2Percentage: 0.72
                y1Percentage: 0.34
                y2Percentage: 0.42
          actions:
            - keyboard_text:
                value: lol123
                duration_s: 0.2
            - keyboard_key:
                value: ret
                duration_s: 0.2
          nextStage: Done
  - stage: Done
    timeout_s: 600
    paths:
      - path:
          checks:
            - file:
              path: 1a.png
              ssim_geq: 0.93
            - file:
              path: 1b.png
              ssim_geq: 0.98
            - file:
              path: 1c.png
              ssim_geq: 0.98
            - file:
              path: 1d.png
              ssim_geq: 0.98
            - file:
              path: 1e.png
              ssim_geq: 0.98
          nextStage: None
```

## Match Highlighting
Every matching image gets now also highlighted with a red frame. Here are a couple of examples.

<img width="800" height="600" alt="matched_1e6cae9f-41d7-4fca-8033-fbd538a65173_0" src="https://github.com/user-attachments/assets/dbe5892d-53ab-4d5d-9366-3e7b84f90fab" />
<img width="1024" height="768" alt="matched_1e6cae9f-41d7-4fca-8033-fbd538a65173_1" src="https://github.com/user-attachments/assets/c628a206-6498-4ffb-b3d0-d57752c14cd5" />
<img width="1024" height="768" alt="matched_1e6cae9f-41d7-4fca-8033-fbd538a65173_2" src="https://github.com/user-attachments/assets/cebe3979-4899-46af-82ef-749aa801cfa1" />
<img width="1024" height="768" alt="matched_1e6cae9f-41d7-4fca-8033-fbd538a65173_3" src="https://github.com/user-attachments/assets/f85f6db2-6132-4064-80ef-08d61155f8dd" />